### PR TITLE
BG3-Text-Chat Improvements

### DIFF
--- a/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/BootstrapClient.lua
+++ b/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/BootstrapClient.lua
@@ -1,2 +1,2 @@
-Ext.Require("Client/Text-Chat_Window.lua")
 Ext.Require("Client/Text-Chat_c.lua")
+Ext.Require("Client/Text-Chat_Window.lua")

--- a/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/BootstrapClient.lua
+++ b/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/BootstrapClient.lua
@@ -1,2 +1,2 @@
-Ext.Require("Client/Text-Chat_c.lua")
 Ext.Require("Client/Text-Chat_Window.lua")
+Ext.Require("Client/Text-Chat_c.lua")

--- a/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_Window.lua
+++ b/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_Window.lua
@@ -1,345 +1,742 @@
-local ACTIVE_ALPHA = 0.9
-local INACTIVE_ALPHA = 0.5
-local DEFAULT_SETTINGS_TEXT = "Click and drag me with middle\nmouse button to move me around!\nTo resize me, click and\ndrag on any of my edges!\nClick the \"Save\" when done!"
-local DEFAULT_GREETING = "~ Welcome to the chat ~"
-
-local chat_size = {493, 225}
-local chat_position = {1415, 375}
-local cached_game_window_width = 1920
-local old_cached_game_window_width = cached_game_window_width
-local settings_visible = false
-
--- Vars for window repositioning and resizing
-local EDGE_SIZE = 3 -- px
-
-local is_moving = false
-local is_left_resizing = false
-local is_top_resizing = false
-local is_right_resizing = false
-local is_bottom_resizing = false
-
-local pressed_coords
-
-function TC_LenStringDisplay(str)
-    local count = 0
-
-    for character in str:gmatch('.') do count = count + (character == '\t' and 4 or 1) end
-    return count
+if not Ext.IsClient() then
+    return
 end
 
-local text_parent = Ext.IMGUI.NewWindow("Text Holder")
-text_parent.NoTitleBar = true
-text_parent:SetPos(chat_position)
-text_parent:SetSize(chat_size)
-text_parent:SetStyle("Alpha", INACTIVE_ALPHA)
-text_parent.NoFocusOnAppearing = true
-text_parent.NoNav = true
-text_parent.NoMove = true
-text_parent.NoResize = true
-text_parent.NoInputs = true
-text_parent.Visible = false
-text_parent.NoScrollbar = true
-
-local text = text_parent:AddText(DEFAULT_GREETING)
-text:SetStyle("Alpha", 1)
-
-local input_parent = Ext.IMGUI.NewWindow("Input Holder")
-input_parent.NoTitleBar = true
-input_parent:SetPos({chat_position[1], chat_position[2] + chat_size[2]})
-input_parent:SetSize({chat_size[1], cached_game_window_width < 2250 and 35 or 70})
-input_parent:SetStyle("Alpha", INACTIVE_ALPHA)
-input_parent.NoMove = true
-input_parent.NoResize = true
-input_parent.Visible = false
-input_parent.NoScrollbar = true
-
-local input = input_parent:AddInputText("")
-input.AllowTabInput = true
-input.EscapeClearsAll = true
-input.ItemWidth = chat_size[1] - cached_game_window_width < 2250 and 69 or 150
-input.OnDeactivate = function()
-    TC_SendMessage(input.Text)
-    input.Text = ""
-
-    text_parent:SetStyle("Alpha", INACTIVE_ALPHA)
-    text_parent.NoInputs = true
-    text_parent.NoScrollbar = true
-
-    input_parent:SetStyle("Alpha", INACTIVE_ALPHA)
-end
-input.OnActivate = function()
-    text_parent:SetStyle("Alpha", ACTIVE_ALPHA)
-    text_parent.NoInputs = false
-    text_parent.NoScrollbar = false
-
-    input_parent:SetStyle("Alpha", ACTIVE_ALPHA)
+if _G.__TEXTCHAT_WINDOW_LOADED then
+    return
 end
 
-local settings_parent = Ext.IMGUI.NewWindow("Settings")
-settings_parent:SetPos(chat_position)
-settings_parent:SetSize({chat_size[1], chat_size[2] + (cached_game_window_width < 2250 and 35 or 70)})
-settings_parent.Visible = false
-settings_parent.NoTitleBar = true
-settings_parent.NoCollapse = true
-settings_parent.NoInputs = true
-settings_parent.NoNav = true
-settings_parent.NoScrollbar = true
+local ok_init, err = pcall(function()
+    local CONFIG = {
+        MinChatW = 360,
+        MinChatH = 140,
+        InputH = 45,
 
-local log = settings_parent:AddText(DEFAULT_SETTINGS_TEXT)
+        ButtonW = 48,
+        ButtonH = 48,
+        ButtonYOffset = 0, -- flush (0px gap)
 
-local settings_button_toggled_holder = Ext.IMGUI.NewWindow("Settings Button Holder")
-settings_button_toggled_holder.SameLine = false
-settings_button_toggled_holder:SetPos({870, 650})
-settings_button_toggled_holder.ItemWidth = 442
-settings_button_toggled_holder:SetSize({290, (cached_game_window_width < 2250 and 35 or 70) * 8 - 7})
-settings_button_toggled_holder.NoTitleBar = true
-settings_button_toggled_holder.Visible = false
-settings_button_toggled_holder.NoMove = true
-settings_button_toggled_holder.NoResize = true
-settings_button_toggled_holder.NoScrollbar = true
+        EdgeSize = 10,
+        ClampMargin = 5,
 
-local game_display_size_1920_button
-local game_display_size_2560_button
-local game_display_size_3440_button
-local game_display_size_3840_button
-game_display_size_1920_button = settings_button_toggled_holder:AddRadioButton("1920x1080", true)
-game_display_size_1920_button.OnActivate = function()
-    game_display_size_2560_button.Active = false
-    game_display_size_3440_button.Active = false
-    game_display_size_3840_button.Active = false
-    cached_game_window_width = 1920
-end
-game_display_size_1920_button.OnChange = function() if not game_display_size_1920_button.Active then game_display_size_1920_button.Active = true end end
-game_display_size_2560_button = settings_button_toggled_holder:AddRadioButton("2560x1440", false)
-game_display_size_2560_button.OnActivate = function()
-    game_display_size_1920_button.Active = false
-    game_display_size_3440_button.Active = false
-    game_display_size_3840_button.Active = false
-    cached_game_window_width = 2560
-end
-game_display_size_2560_button.OnChange = function() if not game_display_size_2560_button.Active then game_display_size_2560_button.Active = true end end
-game_display_size_3440_button = settings_button_toggled_holder:AddRadioButton("3440x1440", false)
-game_display_size_3440_button.OnActivate = function()
-    game_display_size_1920_button.Active = false
-    game_display_size_2560_button.Active = false
-    game_display_size_3840_button.Active = false
-    cached_game_window_width = 3440
-end
-game_display_size_3440_button.OnChange = function() if not game_display_size_3440_button.Active then game_display_size_3440_button.Active = true end end
-game_display_size_3840_button = settings_button_toggled_holder:AddRadioButton("3840x2160", false)
-game_display_size_3840_button.OnActivate = function()
-    game_display_size_1920_button.Active = false
-    game_display_size_2560_button.Active = false
-    game_display_size_3440_button.Active = false
-    cached_game_window_width = 3840
-end
-game_display_size_3840_button.OnChange = function() if not game_display_size_3840_button.Active then game_display_size_3840_button.Active = true end end
+        DefaultActiveAlpha = 0.9,
+        DefaultInactiveAlpha = 0.5,
 
-local clear_button = settings_button_toggled_holder:AddButton("Clear Chat")
-clear_button.SameLine = false
-clear_button.ItemWidth = 178
-clear_button.Size = {178, cached_game_window_width < 2250 and 25.5 or 40}
-clear_button.OnClick = function() text.Label = DEFAULT_GREETING end
+        DefaultGreeting = "~ Welcome to the chat ~",
+        DefaultSettingsText =
+            "\n" ..
+            "Move/Resize:\n" ..
+            "- Enable Move Mode\n" ..
+            "- Use Drag Button (MMB recommended)\n" ..
+            "- Drag edges to resize, center to move\n" ..
+            "Click Save when done.",
 
-local settings_button_toggled = settings_button_toggled_holder:AddButton("Save")
-local settings_button_untoggled = input_parent:AddButton("Settings")
+        DefaultShowTimestamps = false,
+        DefaultFontScale = 1.0,
 
-local function _update_windows()
-    TC_DebugPrint("Updating window dimensions")
-    if cached_game_window_width ~= old_cached_game_window_width then
-        -- Reset the window to default, to enter recovery mode
-        chat_position = {1415, 375}
-        chat_size = {493, 225}
+        DefaultEnterOpensChat = true,
+        DefaultFocusKey = "RETURN",
+
+        DefaultDebugKeys = false,
+    }
+
+    local settings_loaded = false
+    local chat_enabled = true
+    local settings_visible = false
+    local move_mode = true
+    local in_game = false
+
+    local active_alpha = CONFIG.DefaultActiveAlpha
+    local inactive_alpha = CONFIG.DefaultInactiveAlpha
+    local drag_button = 2
+
+    local show_timestamps = CONFIG.DefaultShowTimestamps
+    local font_scale = CONFIG.DefaultFontScale
+
+    local enter_opens_chat = CONFIG.DefaultEnterOpensChat
+    local focus_key = CONFIG.DefaultFocusKey
+
+    local debug_keys = CONFIG.DefaultDebugKeys
+
+    local game_ui_hidden = false
+    local last_root_visible = nil
+
+    local chat_size = {493, 225}
+    local chat_position = {1415, 375}
+    local cached_game_window_width = 1920
+
+    local input_active = false
+
+    local is_moving, is_left_resizing, is_top_resizing, is_right_resizing, is_bottom_resizing =
+        false, false, false, false, false
+    local drag_active = false
+    local drag_start_mouse = {0, 0}
+    local drag_start_pos = {0, 0}
+    local drag_start_size = {0, 0}
+
+    local _apply_visibility
+    local _apply_clickthrough
+    local _update_windows
+    local _save_window_settings
+    local _toggle_settings
+    local _sync_ui_hidden_from_root
+    local _get_root_visible
+    local _get_root_size
+    local _clamp_to_screen
+    local _apply_drag
+    local _begin_drag
+    local _end_drag
+    local _clear_drag_flags
+    local _recompute_drag_mode
+    local _poll_mouse_pos
+    local _apply_minimums
+    local _update_edge_indicator
+    local _current_alpha
+    local _center_settings_panel
+
+    _get_root_visible = function()
+        local ok, root = pcall(function()
+            return Ext.UI.GetRoot and Ext.UI.GetRoot() or nil
+        end)
+        if not ok or not root then return nil end
+
+        local ok1, isVisible = pcall(function() return root:GetProperty("IsVisible") end)
+        if ok1 and isVisible ~= nil then
+            return (isVisible == true)
+        end
+
+        local ok2, visibility = pcall(function() return root:GetProperty("Visibility") end)
+        if ok2 and visibility ~= nil then
+            return (tostring(visibility) == "Visible")
+        end
+
+        local ok3, opacity = pcall(function() return root:GetProperty(".VisualOpacity") end)
+        if ok3 and opacity ~= nil then
+            return (tonumber(opacity) or 1.0) > 0.01
+        end
+
+        return nil
     end
-    old_cached_game_window_width = cached_game_window_width
-    text_parent.NoMove = false
-    text_parent.NoResize = false
-    text_parent:SetPos(chat_position)
-    text_parent:SetSize(chat_size)
+
+    _sync_ui_hidden_from_root = function()
+        local vis = _get_root_visible()
+        if vis == nil then return end
+
+        if last_root_visible == nil or vis ~= last_root_visible then
+            last_root_visible = vis
+            game_ui_hidden = (not vis)
+            _apply_visibility()
+        end
+    end
+
+    _get_root_size = function()
+        local ok, root = pcall(function()
+            return Ext.UI.GetRoot and Ext.UI.GetRoot() or nil
+        end)
+        if not ok or not root then return nil, nil end
+
+        local ok2, props = pcall(function()
+            return root:GetAllProperties(root)
+        end)
+        if not ok2 or not props then return nil, nil end
+
+        return tonumber(props.ActualWidth), tonumber(props.ActualHeight)
+    end
+
+    _apply_minimums = function()
+        chat_size[1] = math.max(chat_size[1], CONFIG.MinChatW)
+        chat_size[2] = math.max(chat_size[2], CONFIG.MinChatH)
+    end
+
+    _clamp_to_screen = function()
+        _apply_minimums()
+
+        local w, h = _get_root_size()
+        if not w or not h then return end
+        cached_game_window_width = w
+
+        local total_h = chat_size[2] + CONFIG.InputH
+        local total_w = chat_size[1]
+
+        chat_position[1] = math.max(CONFIG.ClampMargin, math.min(chat_position[1], w - total_w - CONFIG.ClampMargin))
+
+        local min_y = CONFIG.ClampMargin + CONFIG.ButtonH
+        local max_y = h - total_h - CONFIG.ClampMargin
+        chat_position[2] = math.max(min_y, math.min(chat_position[2], max_y))
+    end
+
+    _poll_mouse_pos = function()
+        local ok, ph = pcall(function()
+            return Ext.UI.GetPickingHelper(1)
+        end)
+        if not ok or not ph then return nil, nil end
+
+        local ok2, pos = pcall(function() return ph.WindowCursorPos end)
+        if not ok2 or type(pos) ~= "table" then return nil, nil end
+
+        local x, y = pos[1], pos[2]
+        if type(x) == "number" and type(y) == "number" then
+            return x, y
+        end
+        return nil, nil
+    end
+
+    _current_alpha = function()
+        return input_active and active_alpha or inactive_alpha
+    end
+
+    _center_settings_panel = function(panel)
+        local w, h = _get_root_size()
+        if not w or not h then
+            panel:SetPos({870, 650})
+            return
+        end
+
+        local panelW, panelH = 360, 420
+        panel:SetPos({
+            math.floor((w - panelW) / 2),
+            math.floor((h - panelH) / 2)
+        })
+    end
+
+    local function _clamp_font_scale(v)
+        v = tonumber(v)
+        if not v then return font_scale end
+        if v < 0.75 then v = 0.75 end
+        if v > 2.0 then v = 2.0 end
+        return v
+    end
+
+    -- IMGUI windows
+    local text_parent = Ext.IMGUI.NewWindow("TextChat_Text")
+    text_parent.NoTitleBar = true
+    text_parent.NoFocusOnAppearing = true
+    text_parent.NoNav = true
     text_parent.NoMove = true
     text_parent.NoResize = true
-    input_parent.NoMove = false
-    input_parent.NoResize = false
-    input_parent:SetPos({chat_position[1], chat_position[2] + chat_size[2]})
-    input_parent:SetSize({chat_size[1], (cached_game_window_width < 2250 and 35 or 70)})
+    text_parent.NoScrollbar = true
+    text_parent.Visible = false
+
+    local text = text_parent:AddText(CONFIG.DefaultGreeting)
+    text:SetStyle("Alpha", 1)
+
+    local input_parent = Ext.IMGUI.NewWindow("TextChat_Input")
+    input_parent.NoTitleBar = true
+    input_parent.NoFocusOnAppearing = true
+    input_parent.NoNav = true
     input_parent.NoMove = true
     input_parent.NoResize = true
-    input.ItemWidth = chat_size[1] - (cached_game_window_width < 2250 and 69 or 150)
-    settings_button_toggled_holder:SetSize({290, (cached_game_window_width < 2250 and 35 or 50) * 8 - 7})
-    settings_parent:SetPos(chat_position)
-    settings_parent:SetSize({chat_size[1], chat_size[2] + (cached_game_window_width < 2250 and 35 or 70)})
-    settings_button_untoggled.PositionOffset = {chat_size[1] - (cached_game_window_width < 2250 and 66 or 140), cached_game_window_width < 2250 and -27 or -54}
-    clear_button.Size = {178, cached_game_window_width < 2250 and 25.5 or 40}
-    settings_button_toggled.Size = {178, cached_game_window_width < 2250 and 25.5 or 40}
-    game_display_size_1920_button.Active = cached_game_window_width == 1920
-    game_display_size_2560_button.Active = cached_game_window_width == 2560
-    game_display_size_3440_button.Active = cached_game_window_width == 3440
-    game_display_size_3840_button.Active = cached_game_window_width == 3840
-    log.Label = DEFAULT_SETTINGS_TEXT
-end
+    input_parent.NoScrollbar = true
+    input_parent.Visible = false
 
-local function _toggle_settings()
-    if settings_visible then
-        text_parent.Visible = true
-        input_parent.Visible = true
+    local input = input_parent:AddInputText("")
+    input.AllowTabInput = true
+    input.EscapeClearsAll = true
 
-        settings_parent.Visible = false
-        settings_button_toggled_holder.Visible = false
+	local function _focus_input()
+		input_active = true
+		_apply_clickthrough() 
 
-        settings_visible = false
+		input.Label = "###Input" .. tostring(Ext.Utils.MonotonicTime())
 
-        TC_DebugPrint("Updating settings")
-        local window_save_table = {
-            WindowXPos = chat_position[1],
-            WindowYPos = chat_position[2],
-            WindowWidth = chat_size[1],
-            WindowHeight = chat_size[2],
-            GameWindowWidth = cached_game_window_width
-        }
-        TC_SaveWindowSettings(window_save_table)
+		Ext.Timer.WaitFor(1, function()
+			if input.Activate then 
+				input:Activate() 
+			end
+		end)
+	end
 
-        _update_windows()
-    else
-        text_parent.Visible = false
-        input_parent.Visible = false
 
-        settings_parent.Visible = true
-        settings_button_toggled_holder.Visible = true
+    local full_overlay = Ext.IMGUI.NewWindow("TextChat_FullOverlay")
+    full_overlay.NoTitleBar = true
+    full_overlay.NoMove = true
+    full_overlay.NoResize = true
+    full_overlay.NoInputs = true
+    full_overlay.NoNav = true
+    full_overlay.NoScrollbar = true
+    full_overlay.Visible = false
+    full_overlay:SetStyle("Alpha", 0.88)
 
-        settings_visible = true
+    local overlay_text = full_overlay:AddText(CONFIG.DefaultSettingsText)
+    overlay_text:SetStyle("Alpha", 1)
+
+    local drag_overlay = Ext.IMGUI.NewWindow("TextChat_DragOverlay")
+    drag_overlay.NoTitleBar = true
+    drag_overlay.NoMove = true
+    drag_overlay.NoResize = true
+    drag_overlay.NoInputs = true
+    drag_overlay.NoNav = true
+    drag_overlay.NoScrollbar = true
+    drag_overlay.Visible = false
+    drag_overlay:SetStyle("Alpha", 0.18)
+
+    local edge_indicator = drag_overlay:AddText("")
+    edge_indicator:SetStyle("Alpha", 1)
+
+    local settings_button_window = Ext.IMGUI.NewWindow("TextChat_SettingsButtonTop")
+    settings_button_window.NoTitleBar = true
+    settings_button_window.NoMove = true
+    settings_button_window.NoResize = true
+    settings_button_window.NoScrollbar = true
+    settings_button_window.NoNav = true
+    settings_button_window.NoFocusOnAppearing = true
+    settings_button_window.Visible = false
+    settings_button_window:SetSize({CONFIG.ButtonW, CONFIG.ButtonH})
+    settings_button_window.NoInputs = false
+
+    local settings_button = settings_button_window:AddImageButton(
+        "SettingsButton",
+        "9735d896-1c99-412f-88ce-1bc3c129db18",
+        {CONFIG.ButtonW * 0.6, CONFIG.ButtonH * 0.6}
+    )
+    settings_button.ItemWidth = CONFIG.ButtonW
+
+    local settings_panel = Ext.IMGUI.NewWindow("TextChat_Settings")
+    settings_panel.NoTitleBar = true
+    settings_panel.NoMove = true
+    settings_panel.NoResize = true
+    settings_panel.NoNav = true
+    settings_panel.Visible = false
+    settings_panel:SetSize({600, 500})
+    settings_panel.NoScrollbar = false -- allow scrolling if needed
+
+    local clear_button = settings_panel:AddButton("Clear Chat")
+    clear_button.ItemWidth = 280
+    clear_button.Size = {280, 28}
+    clear_button.OnClick = function() text.Label = CONFIG.DefaultGreeting end
+
+    local move_mode_button = settings_panel:AddButton("Move Mode: ON")
+    move_mode_button.ItemWidth = 280
+    move_mode_button.Size = {280, 28}
+    move_mode_button.OnClick = function()
+        move_mode = not move_mode
+        move_mode_button.Label = move_mode and "Move Mode: ON" or "Move Mode: OFF"
     end
-end
 
-settings_button_toggled.SameLine = false
-settings_button_toggled.PositionOffset = {0, 0}
-settings_button_toggled.ItemWidth = 178
-settings_button_toggled.Size = {178, cached_game_window_width < 2250 and 25.5 or 40}
-settings_button_toggled.OnClick = _toggle_settings
+    local timestamps_button = settings_panel:AddButton("Timestamps: OFF")
+    timestamps_button.ItemWidth = 280
+    timestamps_button.Size = {280, 28}
+    timestamps_button.OnClick = function()
+        show_timestamps = not show_timestamps
+        timestamps_button.Label = show_timestamps and "Timestamps: ON" or "Timestamps: OFF"
+    end
 
---TC_ShouldDisplayOverheadText = true
---local display_overhead_text_toggle = settings_button_toggled_holder:AddCheckbox("Display text overhead character", TC_ShouldDisplayOverheadText)
---display_overhead_text_toggle.Checked = TC_ShouldDisplayOverheadText
---display_overhead_text_toggle.OnChange = function() TC_ShouldDisplayOverheadText = not TC_ShouldDisplayOverheadText _P(TC_ShouldDisplayOverheadText and 1 or 0) end
+    settings_panel:AddText("Wrap Scale (0.75 - 2.0)")
+    local font_scale_input = settings_panel:AddInputText(tostring(font_scale))
 
-settings_button_untoggled.SameLine = false
-settings_button_untoggled.PositionOffset = {chat_size[1] - (cached_game_window_width < 2250 and 66 or 140), cached_game_window_width < 2250 and -27 or -54}
-settings_button_untoggled.ItemWidth = cached_game_window_width < 2250 and 36 or 72
-settings_button_untoggled.OnClick = _toggle_settings
+    local focus_toggle_button = settings_panel:AddButton("Focus Key Opens Chat: ON")
+    focus_toggle_button.ItemWidth = 280
+    focus_toggle_button.Size = {280, 28}
+    focus_toggle_button.OnClick = function()
+        enter_opens_chat = not enter_opens_chat
+        focus_toggle_button.Label = enter_opens_chat and "Focus Key Opens Chat: ON" or "Focus Key Opens Chat: OFF"
+    end
 
--- local settings_button_untoggled = input_parent:AddImageButton("Settings Button Untoggled", "9735d896-1c99-412f-88ce-1bc3c129db18", {21, 21})
--- settings_button_untoggled.SameLine = false
--- settings_button_untoggled.PositionOffset = {chat_size[1] - 72, -27}--{chat_size[1] - 36, -27}
--- settings_button_untoggled.ItemWidth = 72--36
--- settings_button_untoggled.OnClick = _toggle_settings
+    settings_panel:AddText("Focus Key (KeyInput name, default RETURN)")
+    local focus_key_input = settings_panel:AddInputText(tostring(focus_key))
 
-local function _handle_window_dragging(event)
-    if event.Pressed then
-        -- Left edge resize
-        if event.X >= chat_position[1] - EDGE_SIZE and event.X <= chat_position[1] + EDGE_SIZE
-        and event.Y >= chat_position[2] - EDGE_SIZE and event.Y <= chat_position[2] + chat_size[2] + (cached_game_window_width < 2250 and 35 or 70) + EDGE_SIZE
-        then is_left_resizing = true log.Label = DEFAULT_SETTINGS_TEXT .. "\n\nResizing left edge..."
-        -- Top edge resize
-        elseif event.X >= chat_position[1] - EDGE_SIZE and event.X <= chat_position[1] + chat_size[1] + EDGE_SIZE
-        and event.Y >= chat_position[2] - EDGE_SIZE and event.Y <= chat_position[2] + EDGE_SIZE
-        then is_top_resizing = true log.Label = DEFAULT_SETTINGS_TEXT .. "\n\nResizing top edge..."
-        -- Right edge resize
-        elseif event.X >= chat_position[1] + chat_size[1] - EDGE_SIZE and event.X <= chat_position[1] + chat_size[1] + EDGE_SIZE
-        and event.Y >= chat_position[2] - EDGE_SIZE and event.Y <= chat_position[2] + chat_size[2] + (cached_game_window_width < 2250 and 35 or 70) + EDGE_SIZE
-        then is_right_resizing = true log.Label = DEFAULT_SETTINGS_TEXT .. "\n\nResizing right edge..."
-        -- Bottom edge resize
-        elseif event.X >= chat_position[1] - EDGE_SIZE and event.X <= chat_position[1] + chat_size[1] + EDGE_SIZE
-        and event.Y >= chat_position[2] + chat_size[2] + (cached_game_window_width < 2250 and 35 or 70) - EDGE_SIZE and event.Y <= chat_position[2] + (cached_game_window_width < 2250 and 35 or 70) + chat_size[2] + EDGE_SIZE
-        then is_bottom_resizing = true log.Label = DEFAULT_SETTINGS_TEXT .. "\n\nResizing bottom edge..."
-        -- Move
-        elseif event.X > chat_position[1] + EDGE_SIZE and event.X < chat_position[1] + chat_size[1] - EDGE_SIZE
-        and event.Y > chat_position[2] + EDGE_SIZE and event.Y < chat_position[2] + chat_size[2] + (cached_game_window_width < 2250 and 35 or 70) - EDGE_SIZE
-        then is_moving = true log.Label = DEFAULT_SETTINGS_TEXT .. "\n\nMoving..."
+    local reset_focus_key_button = settings_panel:AddButton("Reset Focus Key")
+    reset_focus_key_button.ItemWidth = 280
+    reset_focus_key_button.Size = {280, 28}
+    reset_focus_key_button.OnClick = function()
+        focus_key = CONFIG.DefaultFocusKey
+        focus_key_input.Text = focus_key
+    end
+
+    local debug_keys_button = settings_panel:AddButton("Debug Key Presses: OFF")
+    debug_keys_button.ItemWidth = 280
+    debug_keys_button.Size = {280, 28}
+    debug_keys_button.OnClick = function()
+        debug_keys = not debug_keys
+        debug_keys_button.Label = debug_keys and "Debug Key Presses: ON" or "Debug Key Presses: OFF"
+    end
+
+    settings_panel:AddText("Active Opacity (0.1 - 1.0)")
+    local active_alpha_input = settings_panel:AddInputText(tostring(active_alpha))
+    settings_panel:AddText("Inactive Opacity (0.1 - 1.0)")
+    local inactive_alpha_input = settings_panel:AddInputText(tostring(inactive_alpha))
+
+    local save_button = settings_panel:AddButton("Save")
+    save_button.ItemWidth = 280
+    save_button.Size = {280, 30}
+
+    input.OnActivate = function()
+        input_active = true
+        local a = _current_alpha()
+        text_parent:SetStyle("Alpha", a)
+        input_parent:SetStyle("Alpha", a)
+        settings_button_window:SetStyle("Alpha", a)
+        _apply_clickthrough()
+    end
+
+    input.OnDeactivate = function()
+        input_active = false
+        TC_SendMessage(input.Text)
+        input.Text = ""
+
+        local a = _current_alpha()
+        text_parent:SetStyle("Alpha", a)
+        input_parent:SetStyle("Alpha", a)
+        settings_button_window:SetStyle("Alpha", a)
+        _apply_clickthrough()
+    end
+
+    _apply_clickthrough = function()
+        local show_chat = in_game and chat_enabled and (not game_ui_hidden)
+        if not show_chat then
+            text_parent.NoInputs = true
+            input_parent.NoInputs = true
+            settings_button_window.NoInputs = true
+            return
         end
 
-        if is_left_resizing or is_top_resizing or is_right_resizing or is_bottom_resizing or is_moving then pressed_coords = {event.X, event.Y} end
-    else
-        if is_left_resizing then
-            chat_position[1] = event.X
-            chat_size[1] = chat_size[1] + pressed_coords[1] - event.X
-        elseif is_top_resizing then
-            chat_position[2] = event.Y
-            chat_size[2] = chat_size[2] + pressed_coords[2] - event.Y
-        elseif is_right_resizing then chat_size[1] = chat_size[1] + event.X - pressed_coords[1]
-        elseif is_bottom_resizing then chat_size[2] = chat_size[2] + event.Y - pressed_coords[2]
-        elseif is_moving then
-            chat_position[1] = chat_position[1] + event.X - pressed_coords[1]
-            chat_position[2] = chat_position[2] + event.Y - pressed_coords[2]
+        if settings_visible then
+            text_parent.NoInputs = true
+            input_parent.NoInputs = true
+            settings_button_window.NoInputs = false
+            return
         end
 
-        if is_left_resizing or is_top_resizing or is_right_resizing or is_bottom_resizing or is_moving then
-            is_left_resizing = false
-            is_top_resizing = false
-            is_right_resizing = false
-            is_bottom_resizing = false
-            is_moving = false
+        text_parent.NoInputs = (not input_active)
+        input_parent.NoInputs = false
+        settings_button_window.NoInputs = false
+    end
 
+    _apply_visibility = function()
+        local show_chat = in_game and chat_enabled and (not game_ui_hidden)
+
+        text_parent.Visible = show_chat
+        input_parent.Visible = show_chat
+        settings_button_window.Visible = show_chat
+
+        full_overlay.Visible = in_game and settings_visible and (not game_ui_hidden)
+        settings_panel.Visible = in_game and settings_visible and (not game_ui_hidden)
+
+        if not drag_active then
+            drag_overlay.Visible = false
+        end
+
+        _apply_clickthrough()
+    end
+
+    _save_window_settings = function()
+        if not settings_loaded then
+            return
+        end
+
+        _clamp_to_screen()
+        TC_SaveWindowSettings({
+            WindowXPos = tonumber(chat_position[1]) or 0,
+            WindowYPos = tonumber(chat_position[2]) or 0,
+            WindowWidth = tonumber(chat_size[1]) or CONFIG.MinChatW,
+            WindowHeight = tonumber(chat_size[2]) or CONFIG.MinChatH,
+            GameWindowWidth = tonumber(cached_game_window_width) or 0,
+
+            ActiveAlpha = tonumber(active_alpha) or CONFIG.DefaultActiveAlpha,
+            InactiveAlpha = tonumber(inactive_alpha) or CONFIG.DefaultInactiveAlpha,
+            DragButton = tonumber(drag_button) or 2,
+
+            ShowTimestamps = show_timestamps,
+            FontScale = font_scale,
+            EnterOpensChat = enter_opens_chat,
+            FocusKey = focus_key,
+        })
+    end
+
+    _update_windows = function()
+        _clamp_to_screen()
+
+        text_parent:SetPos(chat_position)
+        text_parent:SetSize(chat_size)
+
+        input_parent:SetPos({chat_position[1], chat_position[2] + chat_size[2]})
+        input_parent:SetSize({chat_size[1], CONFIG.InputH})
+
+        settings_button_window:SetPos({
+            chat_position[1] + chat_size[1] - CONFIG.ButtonW,
+            (chat_position[2] - CONFIG.ButtonH) + CONFIG.ButtonYOffset
+        })
+        settings_button_window:SetSize({CONFIG.ButtonW, CONFIG.ButtonH})
+
+        full_overlay:SetPos(chat_position)
+        full_overlay:SetSize({chat_size[1], chat_size[2] + CONFIG.InputH})
+        overlay_text.Label = CONFIG.DefaultSettingsText
+
+        drag_overlay:SetPos(chat_position)
+        drag_overlay:SetSize({chat_size[1], chat_size[2] + CONFIG.InputH})
+
+        input.ItemWidth = math.max(chat_size[1] - 20, 80)
+
+        local a = _current_alpha()
+        text_parent:SetStyle("Alpha", a)
+        input_parent:SetStyle("Alpha", a)
+        settings_button_window:SetStyle("Alpha", a)
+
+        timestamps_button.Label = show_timestamps and "Timestamps: ON" or "Timestamps: OFF"
+        focus_toggle_button.Label = enter_opens_chat and "Focus Key Opens Chat: ON" or "Focus Key Opens Chat: OFF"
+        debug_keys_button.Label = debug_keys and "Debug Key Presses: ON" or "Debug Key Presses: OFF"
+    end
+
+    _toggle_settings = function()
+        settings_visible = not settings_visible
+
+        if settings_visible then
+            active_alpha_input.Text = tostring(active_alpha)
+            inactive_alpha_input.Text = tostring(inactive_alpha)
+            font_scale_input.Text = tostring(font_scale)
+            focus_key_input.Text = tostring(focus_key)
+
+            timestamps_button.Label = show_timestamps and "Timestamps: ON" or "Timestamps: OFF"
+            focus_toggle_button.Label = enter_opens_chat and "Focus Key Opens Chat: ON" or "Focus Key Opens Chat: OFF"
+            debug_keys_button.Label = debug_keys and "Debug Key Presses: ON" or "Debug Key Presses: OFF"
+
+            _center_settings_panel(settings_panel)
+        else
+            local aa = tonumber(active_alpha_input.Text)
+            local ia = tonumber(inactive_alpha_input.Text)
+
+            if aa then active_alpha = math.max(0.1, math.min(aa, 1.0)) end
+            if ia then inactive_alpha = math.max(0.1, math.min(ia, 1.0)) end
+
+            font_scale = _clamp_font_scale(font_scale_input.Text)
+
+            local fk = tostring(focus_key_input.Text or ""):upper()
+            if fk ~= "" then
+                focus_key = fk
+            end
+
+            _save_window_settings()
             _update_windows()
         end
+
+        _apply_visibility()
     end
-end
 
-Ext.Events.MouseButtonInput:Subscribe(function (event) if settings_visible and event.Button == 2 then _handle_window_dragging(event) end end)
+    settings_button.OnClick = _toggle_settings
+    save_button.OnClick = _toggle_settings
 
-function TC_UpdateChat(new_message)
-    text.Label = text.Label .. '\n' .. new_message
-    -- Needs to wait for 1 frame to properly get the updated content size
-    Ext.Timer.WaitFor(1, function() text_parent:SetScroll({0.0, 99999999.0}) end)
-end
+    _update_edge_indicator = function()
+        if not drag_active then
+            edge_indicator.Label = ""
+            return
+        end
 
-local function _init_window_settings()
-    local settings = TC_LoadWindowSettings()
-    if not settings or settings == {} or not settings.WindowXPos then
-        TC_DebugPrint("Initializing settings to defaults")
-        settings.WindowXPos = 1415
-        settings.WindowYPos = 375
-        settings.WindowWidth = 493
-        settings.WindowHeight = 225
-        settings.GameWindowWidth = 1920
-        local window_save_table = {
-            WindowXPos = settings.WindowXPos,
-            WindowYPos = settings.WindowYPos,
-            WindowWidth = settings.WindowWidth,
-            WindowHeight = settings.WindowHeight,
-            GameWindowWidth = settings.GameWindowWidth
+        if is_left_resizing then
+            edge_indicator.Label = "Resizing: LEFT"
+        elseif is_right_resizing then
+            edge_indicator.Label = "Resizing: RIGHT"
+        elseif is_top_resizing then
+            edge_indicator.Label = "Resizing: TOP"
+        elseif is_bottom_resizing then
+            edge_indicator.Label = "Resizing: BOTTOM"
+        elseif is_moving then
+            edge_indicator.Label = "Moving"
+        else
+            edge_indicator.Label = ""
+        end
+    end
+
+    _clear_drag_flags = function()
+        is_left_resizing, is_top_resizing, is_right_resizing, is_bottom_resizing, is_moving =
+            false, false, false, false, false
+    end
+
+    _begin_drag = function()
+        if not (in_game and settings_visible and move_mode) then return end
+        local mx, my = _poll_mouse_pos()
+        if not mx or not my then return end
+        if not _recompute_drag_mode(mx, my) then return end
+
+        drag_active = true
+        drag_start_mouse = {mx, my}
+        drag_start_pos = {chat_position[1], chat_position[2]}
+        drag_start_size = {chat_size[1], chat_size[2]}
+        drag_overlay.Visible = true
+        _update_edge_indicator()
+    end
+
+    _end_drag = function()
+        if not drag_active then return end
+        drag_active = false
+        drag_overlay.Visible = false
+        _clear_drag_flags()
+        _update_edge_indicator()
+        _update_windows()
+        _save_window_settings()
+    end
+
+    _recompute_drag_mode = function(mx, my)
+        _clear_drag_flags()
+
+        local top_y = chat_position[2] - CONFIG.ButtonH
+        local bottom_y = chat_position[2] + chat_size[2] + CONFIG.InputH
+
+        if mx >= chat_position[1] - CONFIG.EdgeSize and mx <= chat_position[1] + CONFIG.EdgeSize
+            and my >= top_y - CONFIG.EdgeSize and my <= bottom_y + CONFIG.EdgeSize
+        then
+            is_left_resizing = true
+        elseif mx >= chat_position[1] - CONFIG.EdgeSize and mx <= chat_position[1] + chat_size[1] + CONFIG.EdgeSize
+            and my >= top_y - CONFIG.EdgeSize and my <= top_y + CONFIG.EdgeSize
+        then
+            is_top_resizing = true
+        elseif mx >= chat_position[1] + chat_size[1] - CONFIG.EdgeSize and mx <= chat_position[1] + chat_size[1] + CONFIG.EdgeSize
+            and my >= top_y - CONFIG.EdgeSize and my <= bottom_y + CONFIG.EdgeSize
+        then
+            is_right_resizing = true
+        elseif mx >= chat_position[1] - CONFIG.EdgeSize and mx <= chat_position[1] + chat_size[1] + CONFIG.EdgeSize
+            and my >= bottom_y - CONFIG.EdgeSize and my <= bottom_y + CONFIG.EdgeSize
+        then
+            is_bottom_resizing = true
+        elseif mx > chat_position[1] + CONFIG.EdgeSize and mx < chat_position[1] + chat_size[1] - CONFIG.EdgeSize
+            and my > top_y + CONFIG.EdgeSize and my < bottom_y - CONFIG.EdgeSize
+        then
+            is_moving = true
+        end
+
+        return is_left_resizing or is_top_resizing or is_right_resizing or is_bottom_resizing or is_moving
+    end
+
+    _apply_drag = function(mx, my)
+        if not drag_active then return end
+
+        local dx = mx - drag_start_mouse[1]
+        local dy = my - drag_start_mouse[2]
+
+        if is_moving then
+            chat_position[1] = drag_start_pos[1] + dx
+            chat_position[2] = drag_start_pos[2] + dy
+        elseif is_left_resizing then
+            chat_position[1] = drag_start_pos[1] + dx
+            chat_size[1] = drag_start_size[1] - dx
+        elseif is_right_resizing then
+            chat_size[1] = drag_start_size[1] + dx
+        elseif is_top_resizing then
+            chat_position[2] = drag_start_pos[2] + dy
+            chat_size[2] = drag_start_size[2] - dy
+        elseif is_bottom_resizing then
+            chat_size[2] = drag_start_size[2] + dy
+        end
+
+        _apply_minimums()
+        _clamp_to_screen()
+        _update_windows()
+    end
+
+    Ext.Events.MouseButtonInput:Subscribe(function(event)
+        if event.Button == drag_button then
+            if event.Pressed then
+                _begin_drag()
+            else
+                _end_drag()
+            end
+        end
+    end)
+
+    Ext.Events.Tick:Subscribe(function(_)
+        _sync_ui_hidden_from_root()
+
+        if drag_active then
+            local mx, my = _poll_mouse_pos()
+            if mx and my then
+                _apply_drag(mx, my)
+                _update_edge_indicator()
+            end
+        end
+    end)
+
+    Ext.Events.KeyInput:Subscribe(function(event)
+        if debug_keys and event.Pressed and not event.Repeat then
+            Ext.Utils.Print("[TextChat] KeyInput: " .. tostring(event.Key))
+        end
+
+        if not enter_opens_chat then return end
+        if not in_game or not chat_enabled or game_ui_hidden then return end
+        if settings_visible or drag_active then return end
+        if event.Repeat then return end
+        if not event.Pressed then return end
+        if tostring(event.Key) ~= tostring(focus_key) then return end
+
+        Ext.Utils.Print("[TextChat] Focus key pressed -> focusing input")
+        _focus_input()
+    end)
+
+    function TC_UpdateChat(new_message)
+        text.Label = text.Label .. "\n" .. new_message
+        Ext.Timer.WaitFor(1, function()
+            text_parent:SetScroll({0.0, 99999999.0})
+        end)
+    end
+
+    local function _init_window_settings()
+        local settings = TC_LoadWindowSettings() or {}
+
+        chat_position = {
+            tonumber(settings.WindowXPos) or chat_position[1],
+            tonumber(settings.WindowYPos) or chat_position[2]
         }
-        TC_SaveWindowSettings(window_save_table)
+
+        chat_size = {
+            tonumber(settings.WindowWidth) or chat_size[1],
+            tonumber(settings.WindowHeight) or chat_size[2]
+        }
+
+        local rw = select(1, _get_root_size())
+        cached_game_window_width = tonumber(rw) or tonumber(settings.GameWindowWidth) or cached_game_window_width
+
+        active_alpha = tonumber(settings.ActiveAlpha) or CONFIG.DefaultActiveAlpha
+        inactive_alpha = tonumber(settings.InactiveAlpha) or CONFIG.DefaultInactiveAlpha
+        drag_button = tonumber(settings.DragButton) or drag_button
+
+        show_timestamps = (settings.ShowTimestamps == true)
+        font_scale = _clamp_font_scale(settings.FontScale)
+
+        enter_opens_chat = (settings.EnterOpensChat ~= false)
+        focus_key = tostring(settings.FocusKey or CONFIG.DefaultFocusKey)
+
+        active_alpha_input.Text = tostring(active_alpha)
+        inactive_alpha_input.Text = tostring(inactive_alpha)
+
+        last_root_visible = nil
+        _sync_ui_hidden_from_root()
+
+        settings_loaded = true
+
+        timestamps_button.Label = show_timestamps and "Timestamps: ON" or "Timestamps: OFF"
+        focus_toggle_button.Label = enter_opens_chat and "Focus Key Opens Chat: ON" or "Focus Key Opens Chat: OFF"
+        font_scale_input.Text = tostring(font_scale)
+        focus_key_input.Text = tostring(focus_key)
+        debug_keys_button.Label = debug_keys and "Debug Key Presses: ON" or "Debug Key Presses: OFF"
+
+        _update_windows()
+        _apply_visibility()
     end
 
-    chat_position = {settings.WindowXPos, settings.WindowYPos}
-    chat_size = {settings.WindowWidth, settings.WindowHeight}
-    cached_game_window_width = settings.GameWindowWidth
+    Ext.Events.GameStateChanged:Subscribe(function(event)
+        if event.ToState == "PrepareRunning" then
+            if TC_ResetSessionClock then
+                TC_ResetSessionClock()
+            end
 
-    _update_windows()
-    text_parent.Visible = true
-    input_parent.Visible = true
+            in_game = true
+            _init_window_settings()
+        elseif event.ToState == "UnloadLevel" then
+            in_game = false
+            if settings_loaded then
+                _save_window_settings()
+            end
+
+            settings_visible = false
+            drag_active = false
+            input_active = false
+            game_ui_hidden = true
+            _apply_visibility()
+        end
+    end)
+end)
+
+if not ok_init then
+    Ext.Utils.Print("[TextChat] Window init failed: " .. tostring(err))
+    return
 end
 
-local function handle_game_state_changed(event)
-    if event.ToState == "PrepareRunning" then
-        _init_window_settings()
-    elseif event.ToState == "UnloadLevel" then
-        text_parent.Visible = false
-        input_parent.Visible = false
-        settings_parent.Visible = false
-        settings_button_toggled_holder.Visible = false
-    end
-end
-
-local function handle_key_input(event)
-    if event.Key == "F10" and event.Pressed and not event.Repeat then
-        text_parent.Visible = not text_parent.Visible
-        input_parent.Visible = not input_parent.Visible
-    end
-end
-
-Ext.Events.GameStateChanged:Subscribe(handle_game_state_changed)
-Ext.Events.KeyInput:Subscribe(handle_key_input)
-
--- TODO:
---     - MAYBE configure text size to user's configured text size in the settings?
---       I don't think its possible.
+_G.__TEXTCHAT_WINDOW_LOADED = true

--- a/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_Window.lua
+++ b/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_Window.lua
@@ -715,10 +715,10 @@ local ok_init, err = pcall(function()
         inactive_alpha = tonumber(settings.InactiveAlpha) or CONFIG.DefaultInactiveAlpha
         drag_button = tonumber(settings.DragButton) or drag_button
 
-        show_timestamps = (settings.ShowTimestamps == true)
+        show_timestamps = settings.ShowTimestamps
         font_scale = _clamp_font_scale(settings.FontScale)
 
-        enter_opens_chat = (settings.EnterOpensChat ~= false)
+        enter_opens_chat = not settings.EnterOpensChat
         focus_key = tostring(settings.FocusKey or CONFIG.DefaultFocusKey)
 
         active_alpha_input.Text = tostring(active_alpha)
@@ -770,10 +770,3 @@ if not ok_init then
 end
 
 _G.__TEXTCHAT_WINDOW_LOADED = true
-
--- TODO:
---     - MAYBE configure text size to user's configured text size in the settings?
---       I don't think its possible.
---     - Let chat fade out after some time of inactivity now that focus input works?
---     - Implement /me command for emotes?
---     - Allow changing the drag button?

--- a/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_c.lua
+++ b/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_c.lua
@@ -2,31 +2,164 @@ CHANNEL = "Text-Chat"
 local WINDOW_SETTINGS_PATH = "Data/Text-Chat_Window-Settings.json"
 local MSG_BUFFER_HANDLE = "h7961f8f8g2753g4885gb843gbad96a0098d7"
 
-local cached_window_width
-local cached_game_window_width
+local cached_window_width = 0
+local cached_game_window_width = 1920
+
+local cached_show_timestamps = false
+local cached_font_scale = 1.0
+
+local session_start_ms = nil
 
 function TC_DebugPrint(text) if TC_Debug then Ext.Utils.Print(text) end end
-
 function TC_SetDebug(value) TC_Debug = value end
 
+function TC_LenStringDisplay(str)
+    local count = 0
+    for character in str:gmatch('.') do
+        count = count + (character == '\t' and 4 or 1)
+    end
+    return count
+end
+
+function TC_ResetSessionClock()
+    session_start_ms = Ext.Utils.MonotonicTime()
+end
+
+local function _safe_number(v, default)
+    v = tonumber(v)
+    if v == nil then return default end
+    return v
+end
+
+local function _safe_bool(v, default)
+    if type(v) == "boolean" then return v end
+    if type(v) == "number" then return v ~= 0 end
+    if type(v) == "string" then
+        v = v:lower()
+        if v == "true" or v == "1" then return true end
+        if v == "false" or v == "0" then return false end
+    end
+    return default
+end
+
+local function _safe_string(v, default)
+    if type(v) == "string" and v ~= "" then return v end
+    return default
+end
+
+local function _get_root_width_fallback()
+    if Ext.UI and Ext.UI.GetRoot then
+        local ok, root = pcall(function() return Ext.UI.GetRoot() end)
+        if ok and root then
+            local ok2, props = pcall(function() return root:GetAllProperties(root) end)
+            if ok2 and props and props.ActualWidth then
+                return tonumber(props.ActualWidth)
+            end
+        end
+    end
+    return nil
+end
+
+local function _now_ms()
+    if Ext and Ext.Utils and Ext.Utils.MonotonicTime then
+        return tonumber(Ext.Utils.MonotonicTime()) or 0
+    end
+    if Ext and Ext.Utils and Ext.Utils.GetTime then
+        return tonumber(Ext.Utils.GetTime()) or 0
+    end
+    return 0
+end
+
+local function _format_session_timestamp()
+    local ms = _now_ms()
+    if session_start_ms == nil then
+        session_start_ms = ms
+    end
+    local delta = math.max(0, ms - session_start_ms)
+
+    local total_s = math.floor(delta / 1000)
+    local h = math.floor(total_s / 3600)
+    local m = math.floor((total_s % 3600) / 60)
+    local s = total_s % 60
+
+    if h > 0 then
+        return string.format("[T+%d:%02d:%02d] ", h, m, s)
+    else
+        return string.format("[T+%02d:%02d] ", m, s)
+    end
+end
+
 function TC_SaveWindowSettings(save_data)
-    Ext.IO.SaveFile(WINDOW_SETTINGS_PATH, Ext.Json.Stringify(save_data))
-    cached_window_width = save_data.WindowWidth
-    cached_game_window_width = save_data.GameWindowWidth
+    local normalized = {
+        WindowXPos = _safe_number(save_data.WindowXPos, 0),
+        WindowYPos = _safe_number(save_data.WindowYPos, 0),
+        WindowWidth = _safe_number(save_data.WindowWidth, 493),
+        WindowHeight = _safe_number(save_data.WindowHeight, 225),
+        GameWindowWidth = _safe_number(save_data.GameWindowWidth, _get_root_width_fallback() or 1920),
+
+        ActiveAlpha = _safe_number(save_data.ActiveAlpha, 0.9),
+        InactiveAlpha = _safe_number(save_data.InactiveAlpha, 0.5),
+        DragButton = _safe_number(save_data.DragButton, 2),
+
+        ShowTimestamps = _safe_bool(save_data.ShowTimestamps, false),
+        FontScale = _safe_number(save_data.FontScale, 1.0),
+
+        EnterOpensChat = _safe_bool(save_data.EnterOpensChat, true),
+        FocusKey = _safe_string(save_data.FocusKey, "RETURN"),
+    }
+
+    Ext.IO.SaveFile(WINDOW_SETTINGS_PATH, Ext.Json.Stringify(normalized))
+
+    cached_window_width = normalized.WindowWidth
+    cached_game_window_width = normalized.GameWindowWidth
+    cached_show_timestamps = normalized.ShowTimestamps
+    cached_font_scale = normalized.FontScale
 end
 
 function TC_LoadWindowSettings()
-    local save_data = Ext.Json.Parse(Ext.IO.LoadFile(WINDOW_SETTINGS_PATH) or "{}")
-    cached_window_width = save_data == {} and 0 or save_data.WindowWidth
-    cached_game_window_width = save_data == {} and 1 or save_data.GameWindowWidth -- Don't default to 0 because we might get a DBZ error later.
+    local raw = Ext.IO.LoadFile(WINDOW_SETTINGS_PATH)
+    local save_data = Ext.Json.Parse(raw or "{}")
+    if type(save_data) ~= "table" then
+        save_data = {}
+    end
+
+    local rootW = _get_root_width_fallback()
+
+    cached_window_width = _safe_number(save_data.WindowWidth, 493)
+    cached_game_window_width = _safe_number(save_data.GameWindowWidth, rootW or 1920)
+
+    cached_show_timestamps = _safe_bool(save_data.ShowTimestamps, false)
+    cached_font_scale = _safe_number(save_data.FontScale, 1.0)
+
+    save_data.WindowWidth = cached_window_width
+    save_data.GameWindowWidth = cached_game_window_width
+    save_data.ShowTimestamps = cached_show_timestamps
+    save_data.FontScale = cached_font_scale
+
+    save_data.EnterOpensChat = _safe_bool(save_data.EnterOpensChat, true)
+    save_data.FocusKey = _safe_string(save_data.FocusKey, "RETURN")
+
     return save_data
 end
 
-function TC_SendMessage(message) if message ~= "" then Ext.Net.PostMessageToServer(CHANNEL, message) end end
+function TC_SendMessage(message)
+    if message ~= "" then
+        Ext.Net.PostMessageToServer(CHANNEL, message)
+    end
+end
 
-local function formatted_msg(msg)
+local function _wrap_message(msg)
+    local w = _safe_number(cached_window_width, 493)
+    local gw = _safe_number(cached_game_window_width, _get_root_width_fallback() or 1920)
+    local fontScale = _safe_number(cached_font_scale, 1.0)
+    if fontScale < 0.75 then fontScale = 0.75 end
+    if fontScale > 2.0 then fontScale = 2.0 end
+
     local pretty_msg = ""
-    local max_characters_per_line = cached_window_width / (7 * (cached_game_window_width / 1920))
+    local max_characters_per_line = (w / (7 * (gw / 1920))) / fontScale
+    if max_characters_per_line < 10 then
+        max_characters_per_line = 10
+    end
 
     local characters_in_current_line = 0
     for character in msg:gmatch('.') do
@@ -35,37 +168,52 @@ local function formatted_msg(msg)
         if characters_in_current_line >= max_characters_per_line then
             local curr_character_line_index = pretty_msg:len()
             local prefix, suffix
-            while pretty_msg:sub(curr_character_line_index, curr_character_line_index) ~= ' ' and pretty_msg:sub(curr_character_line_index, curr_character_line_index) ~= '\t' do
+
+            while curr_character_line_index > 0
+                and pretty_msg:sub(curr_character_line_index, curr_character_line_index) ~= ' '
+                and pretty_msg:sub(curr_character_line_index, curr_character_line_index) ~= '\t'
+            do
                 curr_character_line_index = curr_character_line_index - 1
             end
+
             local i = curr_character_line_index - 1
             while i > 0 and pretty_msg:sub(i, i) ~= ' ' do
                 i = i - 1
             end
+
             if i > 0 then
                 prefix = pretty_msg:sub(0, curr_character_line_index)
                 suffix = pretty_msg:sub(curr_character_line_index)
             else
-                prefix = pretty_msg:sub(0, pretty_msg:len() - 1)
-                suffix = pretty_msg:sub(pretty_msg:len() - 1)
-
+                prefix = pretty_msg:sub(0, math.max(pretty_msg:len() - 1, 0))
+                suffix = pretty_msg:sub(math.max(pretty_msg:len() - 1, 0))
                 prefix = prefix .. "-"
             end
-            pretty_msg = prefix .. "\n\t\t" .. suffix .. character
 
+            pretty_msg = prefix .. "\n\t\t" .. suffix .. character
             characters_in_current_line = 4 + TC_LenStringDisplay(suffix .. character)
-        else pretty_msg = pretty_msg .. character
+        else
+            pretty_msg = pretty_msg .. character
         end
     end
+
     return pretty_msg
+end
+
+function TC_FormatChatMessage(payload)
+    local prefix = ""
+    if cached_show_timestamps then
+        prefix = _format_session_timestamp()
+    end
+    return prefix .. _wrap_message(payload)
 end
 
 Ext.Events.NetMessage:Subscribe(function (event)
     if event.Channel == CHANNEL then
-        if event.Payload:sub(1, 5) == "[OHT]" then -- Overhead text update command
+        if event.Payload:sub(1, 5) == "[OHT]" then
             Ext.Loca.UpdateTranslatedString(MSG_BUFFER_HANDLE, event.Payload:sub(7, event.Payload:len()))
         else
-            TC_UpdateChat(formatted_msg(event.Payload)) -- Output all received Text-Chat messages.
+            TC_UpdateChat(TC_FormatChatMessage(event.Payload))
         end
     end
 end)

--- a/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_c.lua
+++ b/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_c.lua
@@ -92,7 +92,7 @@ local function _format_session_timestamp()
 end
 
 function TC_SaveWindowSettings(save_data)
-    local normalized = {
+    local cached_settings = {
         WindowXPos = _safe_number(save_data.WindowXPos, 0),
         WindowYPos = _safe_number(save_data.WindowYPos, 0),
         WindowWidth = _safe_number(save_data.WindowWidth, 493),
@@ -110,12 +110,12 @@ function TC_SaveWindowSettings(save_data)
         FocusKey = _safe_string(save_data.FocusKey, "RETURN"),
     }
 
-    Ext.IO.SaveFile(WINDOW_SETTINGS_PATH, Ext.Json.Stringify(normalized))
+    Ext.IO.SaveFile(WINDOW_SETTINGS_PATH, Ext.Json.Stringify(cached_settings))
 
-    cached_window_width = normalized.WindowWidth
-    cached_game_window_width = normalized.GameWindowWidth
-    cached_show_timestamps = normalized.ShowTimestamps
-    cached_font_scale = normalized.FontScale
+    cached_window_width = cached_settings.WindowWidth
+    cached_game_window_width = cached_settings.GameWindowWidth
+    cached_show_timestamps = cached_settings.ShowTimestamps
+    cached_font_scale = cached_settings.FontScale
 end
 
 function TC_LoadWindowSettings()


### PR DESCRIPTION
Hey there.

First off I wanted to thank you for this lovely amazing mod that allows me to play this well with a buddy of mine.

However after having the position of the window constantly reset and reading that you were not going to fix that any time soon I figured I might as well try fix it locally.

And in the process of doing so I managed to dig further and basically refactored most of the UI code and added a bunch of new features.

This is the first BG3 mod I have tried contributing to so forgive me if I have missed anything obvious.

I've added/changed these things to the mod.

- Fixed a bug that was saving the UI before loading it (the original bug).
- Showing/hiding the chat now properly tracks the ingame HUD using the UI root.
- Get the window size (mainly the width) from the root to determine what the users resolution is.
- Clamp the position of the chat.
- Introduce minimum sizes for the chat.
- Reintroduced the settings image button because the settings text button kept going out of bounds and kept being wonky, has it's own window now that is sort of attached to the chat.
- Make it to see the window visually move by polling the mouse position every tick while dragging.
- Allow users to immediately get to the text input with a focus key (enter by default since it seems it's not bound/used by BG3 by default) and made it configurable.
- Introduce timestamps, since we can only use MonotonicTime we can only track the session length and not the OS time.
- Allow users to change the wrap scale.
- Allow users to configure the opacity of the window.

That's about it for now, the focus input is kinda hacky but it's the only possible way it worked with this version of ImGui (truly a pain to work with) after trying a LOT of different things.

I would love to hear from you, I'm open to adding more stuff!

https://github.com/user-attachments/assets/4ebc663d-0bed-4c78-bf7d-f6a064233b0c


Here's a short video I recorded my buddy to show the changes!