### PR TITLE
Make timestamps use actual time

### DIFF
--- a/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_Window.lua
+++ b/BG3-Text-Chat/Mods/BG3-Text-Chat/ScriptExtender/Lua/Client/Text-Chat_Window.lua
@@ -743,10 +743,6 @@ local ok_init, err = pcall(function()
     -- Resets transient UI state and persists window settings on unload.
     Ext.Events.GameStateChanged:Subscribe(function(event)
         if event.ToState == "PrepareRunning" then
-            if TC_ResetSessionClock then
-                TC_ResetSessionClock()
-            end
-
             in_game = true
             _init_window_settings()
         elseif event.ToState == "UnloadLevel" then


### PR DESCRIPTION
Ext.Timer.ClockTime() will get the regular time without timezone but also gets the full date so opted to use Ext.Timer.ClockEpoch() which is easier to work with.

No easy way to set DST etc so for now there's a ClockOffsetMinutes settings you can set in the JSON (feels like it's too specific to put in the Config Window for now) to account for this. For example it's 02:32 atm (AM) but the game will show 01:32 because it has no regard for DST.